### PR TITLE
Modification du vm.box : passage de CentOS7 à RockyLinux 8

### DIFF
--- a/00_lab-00/Vagrantfile
+++ b/00_lab-00/Vagrantfile
@@ -1,6 +1,6 @@
 Vagrant.configure("2") do |config|
   config.vm.define "ca" do |ca|
-    ca.vm.box = "geerlingguy/centos7"
+    ca.vm.box = "generic/rocky8"
     ca.vm.hostname = "ca"
     ca.vm.provider "virtualbox" do |vb|
       vb.memory = "2048"
@@ -9,7 +9,7 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.define "webserver" do |webserver|
-    webserver.vm.box = "geerlingguy/centos7"
+    webserver.vm.box = "generic/rocky8"
     webserver.vm.hostname = "webserver"
     webserver.vm.provider "virtualbox" do |vb|
       vb.memory = "2048"


### PR DESCRIPTION
Ce changement met à jour le type de box utilisé dans le Vagrantfile en remplaçant *geerlingguy/centos7,** basé sur CentOS 7 désormais en fin de vie, par generic/rocky8, une box Rocky Linux 8 supportée et maintenue. Cette mise à jour garantit l’accès à des dépôts disponibles et fonctionnels, assure la compatibilité avec les gestionnaires de paquets dnf/yum, et offre un meilleur support à long terme grâce à Rocky Linux, successeur officiel de CentOS.